### PR TITLE
Исправлено(crab_syntax): ложные срабатывания strongbash017

### DIFF
--- a/bin/crab_syntax
+++ b/bin/crab_syntax
@@ -5,6 +5,7 @@ set -eu
 . /opt/crab/crab_utils/bin/::carbon.sys
 
 sys::usage "$@"
+
 # --help Info:
 # --help Утилита проверки синтаксиса и ошибок bash в стиле set -eu
 # --help обязательна для всех новых файлов с 2017 года
@@ -25,6 +26,12 @@ if [ "${1:-}" = "--maybe" ]; then
 fi
 
 SYNTAX_STYLE=${2:-bash}
+
+# чтобы правильно считать длину кириллических строк
+# будучи вызванным в неполном окружении
+if [ -z "${LANG:-}" -a -z "${LC_CTYPE:-}" ]; then
+	export LANG=ru_RU.UTF-8
+fi
 
 if [ -d "$1" ]; then
 	DIR="$1"


### PR DESCRIPTION
На MacOS вызов crab_syntax из pycharm в виде external tools вызывает ложные срабатывания.
Из-за неустановленных переменных LC_CTYPE и LANG bash считает длину unicode-строк по
два символа на каждый кириллический символ.