### PR TITLE
Fixed(git syntax check hook): prevent vim from writing to viminfo.

### DIFF
--- a/bin/crab_indent
+++ b/bin/crab_indent
@@ -18,7 +18,7 @@ fi
 
 case "${2:-bash}" in
 bash)
-	vim -T dumb -u /opt/crab/crab_utils/bin/crab_indent.vimrc \
+	vim -i NONE -T dumb -u /opt/crab/crab_utils/bin/crab_indent.vimrc \
 		-c ':normal gg=G' -c ':x' "$1" -s /dev/null &>/dev/null </dev/null
 	;;
 *)


### PR DESCRIPTION
We're just avoiding troubleshooting with writing permissions for gitlab when using syntax hooks by this commit